### PR TITLE
[enh] Highlight discord server in content

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -7,17 +7,51 @@ show_sidebar: false
 hero_height: is-small
 ---
 
-## Ready to get started ?
+This guide is intended to help get Dev Days participants up-and-running with both:
 
-In this section we explain briefly how to get up and running in a minimal number of steps.
+1. the infrastructure for the 2021 Dev Days event, as well as
+1. development environments for the nilearn and nibabel code bases.
 
-### Install Python
+## Sprint infrastructure
 
-The firts step is obviously to have Python installed and working. We recommand having a version of Python higher or equal to 3.6. If you don't have Python installed already, you can get it on the [official website](https://www.python.org/downloads/).
+To create more dynamic time together (albeit remotely), we have created a [Nilearn-Nibabel-Dev-Days Discord](https://discord.gg/bMBhb7w) room.
+Important event announcements will be made on both Discord “general” channel and the [dedicated GitHub issue](https://github.com/nilearn/nilearn/issues/2739).
+
+Although we welcome any and all questions on Discord,
+for transparency and continuity of development after the event we will encourage all technical discussions to be documented on GitHub on either the
+[nilearn](https://github.com/nilearn/nilearn) or [nibabel](https://github.com/nipy/nibabel) issue board, as appropriate.
+
+### Daily organization
+
+To say hello and organize work, we will have two introductory meetings on Wednesday at 9:30a CET and 9:30a EDT.
+To share progress we will have another common session on Thursday 5:00p CET, 11a EDT.
+
+You can find all relevant events in [the sprint calendar](https://calendar.google.com/calendar/b/3?cid=bmlsZWFybi5ldmVudHNAZ21haWwuY29t).
+We welcome all contributors to schedule discussions for specific topics of interest.
+These sessions should be announced with at least a few hours notice on both the GitHub issue and Discord room.
+
+We will consider the sprint hours to run roughly from 9:00a CET to 6:00p EDT.
+We do not expect anyone to attend all (or most !) of that time !
+These are just the times when at least one current Nilearn core developer will be online to help with general questions and point towards available resources.
+
+### An introduction to Discord
+
+Discord is a chat platform that allows for both voice and text communication. If you are new to discord, we encourage you to read the quick introduction guide [here](https://support.discord.com/hc/en-us/articles/360045138571-Beginner-s-Guide-to-Discord), which explains the basics of Discord.
+
+In the left panel, you can modify settings at the top (notifications, privacy…) and see all available channels below (text and voice). In the right panel you can see who is connected and contact them directly.
+
+The general channels will be for welcoming, general announcements, and asking general questions.
+A break channel is dedicated to sharing breaks together. You can create other channels to accommodate specific needs (for example, setting up your development environment).
+
+Notifications can be a bit overwhelming on Discord, don’t hesitate to filter them out while working (muting channels with right-click or setting your account on Do Not Disturb).
+
+## Setting up a development environment
+
+The first step is obviously to have Python installed and working. We recommand having a version of Python higher or equal to 3.6. If you don't have Python installed already, you can get it on the [official website](https://www.python.org/downloads/).
 
 ### Install Nilearn and Nibabel
 
-Once you have Python installed correclty on your machine, you need to install [Nilearn](https://github.com/nilearn/nilearn),  [Nibabel](https://github.com/nipy/nibabel) and their dependencies. Both Nilearn and Nibabel are available through Pypi ([Nilearn link](https://pypi.org/project/nilearn/), [Nibabel link](https://pypi.org/project/nibabel/)) such that you should be able to pip-install them. 
+Once you have Python installed correclty on your machine, you need to install [Nilearn](https://github.com/nilearn/nilearn),  [Nibabel](https://github.com/nipy/nibabel) and their dependencies. Both Nilearn and Nibabel are available through Pypi ([Nilearn link](https://pypi.org/project/nilearn/), [Nibabel link](https://pypi.org/project/nibabel/)) such that you should be able to pip-install them.
 
 Actually, since Nibabel is a dependency of Nilearn, you can simply install everything you need by running:
 
@@ -37,32 +71,3 @@ Finally, when you are ready to contribute, you can browse the issues we have sel
 
 - [Nilearn project board](https://github.com/nilearn/nilearn/projects/6)
 - [Nibabel project board](https://github.com/nipy/nibabel/projects/1).
-
-## Sprint infrastructure
-
-- Technical discussions should take place on [GitHub](https://github.com/nilearn/nilearn) as usual to keep track of development and have open discussions.
-- To create more dynamic time together (albeit remotely), we have created a [Nilearn-Nibabel-Dev-Days Discord](https://discord.gg/bMBhb7w) room.
-  You can find a quick introduction to the Discord platform at the end of this page.
-- Important announcements will be made on both Discord “general” channel and the [dedicated issue](https://github.com/nilearn/nilearn/issues/2739).
-
-## Daily organization
-
-- To say hello and organize work, we will have two introductory meetings on Wednesday at 9:30a CET and 9:30a EDT.
-  To share progress we will have another common session on Thursday 5:00p CET, 11a EDT.
-- You can find all relevant events in [the sprint calendar](https://calendar.google.com/calendar/b/3?cid=bmlsZWFybi5ldmVudHNAZ21haWwuY29t).
-- We welcome all contributors to schedule discussions for specific topics of interest.
-  These sessions should be announced with at least a few hours notice on both the GitHub issue and Discord room.
-- We will consider the sprint hours to run roughly from 9:00a CET to 6:00p EDT.
-  We do not expect anyone to attend all (or most !) of that time !
-  These are just the times when at least one current Nilearn core developer will be online to help with general questions and point towards available resources.
-
-## An introduction to Discord
-
-Discord is a chat platform that allows for both voice and text communication. If you are new to discord, we encourage you to read the quick introduction guide [here](https://support.discord.com/hc/en-us/articles/360045138571-Beginner-s-Guide-to-Discord), which explains the basics of Discord.
-
-In the left panel, you can modify settings at the top (notifications, privacy…) and see all available channels below (text and voice). In the right panel you can see who is connected and contact them directly.
-
-The general channels will be for welcoming, general announcements, and asking general questions.
-A break channel is dedicated to sharing breaks together. You can create other channels to accommodate specific needs (for example, setting up your development environment).
-
-Notifications can be a bit overwhelming on Discord, don’t hesitate to filter them out while working (muting channels with right-click or setting your account on Do Not Disturb).

--- a/index.md
+++ b/index.md
@@ -11,9 +11,15 @@ It provides statistical and machine-learning tools, with instructive documentati
 
 [Nibabel](https://nipy.org/nibabel/) provides read and write access to some common medical and neuroimaging file formats.
 
-In the 2021 Dev Days, we hope to onboard new contributors to our community and explore future directions for development.
+In the 2021 Dev Days, we hope to onboard new contributors to our communities and explore future directions for development.
 
-## Schedule
+To create more dynamic time together (albeit remotely), we have created a [Nilearn-Nibabel-Dev-Days Discord](https://discord.gg/bMBhb7w) server.
+We will be holding all community discussions there, so we encourage you to join and introduce yourself on the platform !
+
+If you need help getting started with Discord or with navigating the Nilearn and Nibabel code bases,
+check out our [getting started guide](https://nilearn.github.io/dev-days-2021/getting-started.html).
+
+## Event schedule
 
 Although we encourage hacking throughout the Dev Days, we wanted to include a few structured events during a smaller portion
 of the day when both our European and American contributors are likely to be awake.


### PR DESCRIPTION
Makes the Discord server link easier to find, lightly re-organizes "getting started" content.